### PR TITLE
Add button to bring user back to all strains

### DIFF
--- a/src/components/CardContainer/CardContainer.js
+++ b/src/components/CardContainer/CardContainer.js
@@ -40,6 +40,7 @@ export class CardContainer extends Component {
 
   selectCategory = category => {
     this.props.setCategory(category);
+    this.props.setUniqueEffect('');
   };
 
   sendUniqueEffect = event => {

--- a/src/components/Strain/Strain.js
+++ b/src/components/Strain/Strain.js
@@ -49,7 +49,7 @@ export const Strain = ({
       const splitEffect = uniqueEffect.split('_');
       const effectType = splitEffect[0];
       const effectName = splitEffect[1];
-      area = effectName;
+      area = `${category}-${effectType}-${effectName}`.toLowerCase();
       allStrains = allStrains.filter(strain =>
         strain.effects[effectType].includes(effectName)
       );
@@ -72,7 +72,16 @@ export const Strain = ({
 
   return (
     <section>
-      <h2 className="area">{area}</h2>
+      <div className="category-container">
+        <h2 className="area">{area}</h2>
+        <button
+          className="all-strains_button"
+          type="button"
+          onClick={() => window.location.reload()}
+        >
+          Back To All Strains
+        </button>
+      </div>
       <section className="strain-container">{cards}</section>
     </section>
   );

--- a/src/components/Strain/Strain.scss
+++ b/src/components/Strain/Strain.scss
@@ -40,3 +40,14 @@
   margin: 0;
   text-align: center;
 }
+
+.category-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+.all-strains_button {
+  border-radius: 5px;
+  height: 2.5em;
+  margin: 2em;
+}


### PR DESCRIPTION
What does this PR do?

This PR adds a button that will allow the user to return to a display of all possible strains in CardContainer and changes the category name to reflect the exact location the user is searching

Where should a reviewer start?

CardContainer.js and Strain.js

This resloves #16 and #17 